### PR TITLE
fix: typo na instância da classe Intents

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,9 +9,9 @@ load_dotenv(find_dotenv('.venv/.env'))
 TOKEN = os.getenv('DISCORD_TOKEN')
 
 # Configurando as necessidades do bot: Ler e enviar mensagens
-intests = Intents.default()
-intests.message_content = True
-client = Client(intents=intests)
+intents = Intents.default()
+intents.message_content = True
+client = Client(intents=intents)
 
 # Funcionalidades de mensagem
 async def send_message(message: Message, user_message: str) -> None:


### PR DESCRIPTION
Tem um typo no arquivo `main` que acredito que era pra ser `intents` ao invés de `intests`.